### PR TITLE
add bin/ to .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,3 +3,4 @@ out/
 .env
 .env.prod
 node_modules/
+bin/


### PR DESCRIPTION

## Motivation:

Having `bin/` included leads to messy version control from build files being uploaded

## Modifications:

Added it to `.gitignore`. Test by running `make build` then trying to stage a commit. 

## Result:

No `bin/` files in codebase
